### PR TITLE
Ensure function iterates over all results from google

### DIFF
--- a/src/google.ts
+++ b/src/google.ts
@@ -26,24 +26,31 @@ export async function getAdminService() {
 
 export async function getGithubUsersFromGoogle(): Promise<Set<string>> {
   const service = await mod.getAdminService()
+  let githubAccounts = new Set<string>()
+  let pageToken = null
 
-  const userList = await service.users.list({
-    customer: 'my_customer',
-    maxResults: 250,
-    projection: 'custom',
-    fields: 'users(customSchemas/Accounts/github(value))',
-    customFieldMask: 'Accounts',
-  })
-
-  const githubAccounts = mod.formatUserList(userList.data.users)
+  do {
+    const userList = await service.users.list({
+      customer: 'my_customer',
+      maxResults: 250,
+      projection: 'custom',
+      fields: 'users(customSchemas/Accounts/github(value)),nextPageToken',
+      customFieldMask: 'Accounts',
+      pageToken: pageToken,
+    })
+    pageToken = userList.data.nextPageToken
+    githubAccounts = new Set([...githubAccounts, ...formatUserList(userList.data.users)])
+  } while (pageToken != null)
   return githubAccounts
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export function formatUserList(users): Set<string> {
+export function formatUserList(users: any[]): Set<string> {
   return new Set(
     users
-      .map((user) => user.customSchemas?.Accounts?.github?.map((account) => account.value?.toLowerCase()))
+      .map((user) =>
+        user.customSchemas?.Accounts?.github?.map((account: { value: string }) => account.value?.toLowerCase()),
+      )
       .flat()
       .filter(Boolean),
   )


### PR DESCRIPTION
This search works as a filter so it can return fewer results than the page
size, and page size maxes out at 500. This PR ensures that it will iterate over all pages of results.
