### PR TITLE
fix(SA-675): Add packages write permission and fix Dockerfile CMD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ COPY package.json package-lock.json ./
 RUN npm install --production
 COPY . .
 
-CMD cd /app && npm start 
+CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- Add `permissions` block with `packages: write` to allow pushing to GitHub Packages registry
- Change Dockerfile CMD from shell form to JSON array format for proper OS signal handling

## Problem
The CI workflow was failing with:
```
ERROR: denied: installation not allowed to Write organization package
```

Additionally, Docker was warning:
```
JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals
```

## Changes
1. **ci.yml**: Added permissions block
2. **Dockerfile**: Changed CMD to JSON array format

## Test Plan
- [ ] CI workflow completes successfully
- [ ] Docker image is pushed to GitHub Packages