### PR TITLE
Migrate docker image hosting from docker.pkg.github.com to ghcr.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,12 @@ jobs:
       - id: docker_meta
         uses: crazy-max/ghaction-docker-meta@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
-          images: docker.pkg.github.com/appvia/githubUserManager/githubUserManager
+          images: ghcr.io/appvia/githubusermanager
           flavor: |
             latest=true
           tags: |
             type=sha
-            type=semver,pattern={{version}}
+            type=semver,pattern=v{{version}}
           labels: |
             org.opencontainers.image.vendor=appvia
             org.opencontainers.image.documentation=https://github.com/appvia/githubUserManager
@@ -53,11 +53,11 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4 # v4.3.0
         with:
-          registry: docker.pkg.github.com
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push to GitHub Packages
+      - name: Push to ghcr.io
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           push: ${{ github.event_name != 'pull_request' }}

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ updates:
 #### Docker
 
 1. Make an [env file](https://www.digitalocean.com/community/tutorials/how-to-read-and-set-environmental-and-shell-variables-on-linux) with the [below table](#Setup-environment-variables)
-1. `docker run --env-file .env docker.pkg.github.com/appvia/githubusermanager/githubusermanager:main`
+1. `docker run --env-file .env ghcr.io/appvia/githubusermanager:latest`
 
 #### node/lambda/cloud run/ something else
 

--- a/action.yml
+++ b/action.yml
@@ -59,9 +59,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Login to docker.pkg.github.com
+    - name: Login to ghcr.io
       shell: bash
-      run: echo ${PASSWORD} | docker login --username ${USERNAME} --password-stdin docker.pkg.github.com
+      run: echo ${PASSWORD} | docker login --username ${USERNAME} --password-stdin ghcr.io
       env:
         USERNAME: ${{ inputs.github-actor }}
         PASSWORD: ${{ inputs.github-token }}
@@ -82,7 +82,7 @@ runs:
         -e SLACK_NOTIFY_ON_ERROR="$SLACK_NOTIFY_ON_ERROR" \
         -e SLACK_NOTIFY_ON_CHANGE="$SLACK_NOTIFY_ON_CHANGE" \
         -e SLACK_NOTIFY_ALWAYS="$SLACK_NOTIFY_ALWAYS" \
-        docker.pkg.github.com/appvia/githubusermanager/githubusermanager:v1.0.5
+        ghcr.io/appvia/githubusermanager:${{ github.action_ref }}
       shell: bash
       env:
         GOOGLE_EMAIL_ADDRESS: ${{ inputs.google-email-address }}


### PR DESCRIPTION
## Summary
- Move image build/push (ci.yml) and pull (action.yml) from the deprecated `docker.pkg.github.com` to `ghcr.io`, using a simplified path (`ghcr.io/appvia/githubusermanager`).
- Fix the semver tag to keep its `v` prefix (`v1.0.5` instead of `1.0.5`) so it matches the tag `action.yml` actually requests via `github.action_ref`.
- Update the README's stale `docker run ...:main` example to `ghcr.io/appvia/githubusermanager:latest` (a tag that is actually produced by the workflow).

## Follow-up required (not part of this PR)
After this merges and the next push/release pushes an image to ghcr.io for the first time, an org admin needs to set the package visibility to **public** in GitHub package settings — ghcr.io defaults new packages to private, which would otherwise break external consumers pulling the action.

## Test plan
- [ ] CI (`ci.yml`) runs successfully on this PR (build/lint/test steps; push step skipped for PRs)
- [ ] After merge, confirm a push to `main` pushes `ghcr.io/appvia/githubusermanager:latest` and `:sha-*`
- [ ] After next release, confirm `ghcr.io/appvia/githubusermanager:vX.Y.Z` is pushed and matches what a consumer pinning `@vX.Y.Z` pulls
- [ ] Set package visibility to public, then confirm a consumer workflow can pull and run the action end-to-end